### PR TITLE
[red-night] Fix job history comparison table

### DIFF
--- a/css/red-night.css
+++ b/css/red-night.css
@@ -953,3 +953,20 @@ div.popover.toptempPopover .popover-content div.TopTempPopoverGraph svg .ct-labe
 #settings_plugin_bedlevelvisualizer #bedlevelvisualizer_command {
     min-height: 300px;
 }
+
+#dialog_printJobHistory_compareSlicerSettings.modal {
+    width: 1000px;
+    margin-left: -500px
+}
+
+#dialog_printJobHistory_compareSlicerSettings table thead th {
+    background: var(--grey1) !important;
+}
+
+#dialog_printJobHistory_compareSlicerSettings table tbody tr span[style*="black"] {
+    color: var(--quiteWhite) !important;
+}
+
+#dialog_printJobHistory_compareSlicerSettings table tbody tr span[style*="blue"] {
+    color: var(--accent-darker) !important;
+}


### PR DESCRIPTION
Adjust PrintJobHistory plugin to the red-night theme.

Before:

![2021-04-26 22_58_53-OctoPrint 0% Eta_ - (offline)](https://user-images.githubusercontent.com/5469257/116150041-24325f00-a6e3-11eb-94b5-624c7a792c24.png)


After:

![2021-04-26 22_57_56-OctoPrint 0% Eta_ - (offline)](https://user-images.githubusercontent.com/5469257/116150053-27c5e600-a6e3-11eb-8e64-0c78abe0b0dc.png)
