### PR TITLE
Discorded popover title/arrow fix

### DIFF
--- a/css/discorded.css
+++ b/css/discorded.css
@@ -505,6 +505,28 @@ body::-webkit-resizer, body .scrollable::-webkit-resizer, .scroll-wrapper::-webk
   border-color: var(--accent);
 }
 
+.popover-title {
+  background-color: #474a51;
+  border-color: var(--accent);
+}
+
+.popover.top .arrow:after {
+  border-top-color: var(--accent);
+}
+
+.popover.bottom .arrow:after {
+  border-bottom-color: var(--accent);
+}
+
+.popover.left .arrow:after {
+  border-left-color: var(--accent);
+}
+
+
+.popover.right .arrow:after {
+  border-right-color: var(--accent);
+}
+
 div.popover.toptempPopover {
     background-color: var(--background);
 }


### PR DESCRIPTION
#22 missed title and arrow. Adjusted in this PR

Before:
![image](https://user-images.githubusercontent.com/1585573/130165985-0408b433-2852-498b-9085-4e180d790a25.png)


After:
![image](https://user-images.githubusercontent.com/1585573/130165931-bd686800-ed1c-4aec-ba02-6ffd3d96dd8d.png)
