### PR TITLE
Fix popover in Dark Green theme.

### DIFF
--- a/css/darkgreen.css
+++ b/css/darkgreen.css
@@ -540,3 +540,11 @@ input[disabled], select[disabled], textarea[disabled], input[readonly], select[r
     background-color: var(--lighterish);
     border: var(--darkerWhite);
 }
+.popover {
+    background-color: var(--darkish);
+    border-color: var(--green);
+}
+.popover-title {
+    background-color: var(--notquiteBlack);
+    border-color: var(--green);
+}

--- a/css/darkgreen.css
+++ b/css/darkgreen.css
@@ -542,9 +542,21 @@ input[disabled], select[disabled], textarea[disabled], input[readonly], select[r
 }
 .popover {
     background-color: var(--darkish);
-    border-color: var(--green);
+    border-color: var(--accent);
 }
 .popover-title {
     background-color: var(--notquiteBlack);
-    border-color: var(--green);
+    border-color: var(--accent);
+}
+.popover.top .arrow:after {
+    border-top-color: var(--accent);
+}
+.popover.bottom .arrow:after {
+    border-bottom-color: var(--accent);
+}
+.popover.left .arrow:after {
+    border-left-color: var(--accent);
+}
+.popover.right .arrow:after {
+    border-right-color: var(--accent);
 }


### PR DESCRIPTION
Dark Green seems to be the only theme that doesn't properly theme popovers. This should fix most of the issues with popovers in this theme. I did _not_ attempt to fix the chart backgrounds for TopTemp - just the main popover theme.